### PR TITLE
Fix layout problem in React Native 0.36

### DIFF
--- a/GridLayoutExample/index.ios.js
+++ b/GridLayoutExample/index.ios.js
@@ -86,9 +86,10 @@ var hashCode = function(str) {
 
 var styles = StyleSheet.create({
   list: {
-    justifyContent: 'center',
     flexDirection: 'row',
-    flexWrap: 'wrap'
+    justifyContent: 'space-between',
+    flexWrap:'wrap',
+    alignItems: 'flex-start',
   },
   row: {
     justifyContent: 'center',


### PR DESCRIPTION
Old layout can not be shown properly in react native 0.36, it should be add alignItems and change justifyContent.